### PR TITLE
Jolie2Java compatibility and version handling

### DIFF
--- a/generators/app/docker.js
+++ b/generators/app/docker.js
@@ -3,7 +3,7 @@ const Generator = require('yeoman-generator')
 module.exports = class extends Generator {
 	constructor (args, opts) {
 		super(args, opts)
-		this.module_name = opts.module.name
+		this.jolieVersion = opts.jolieVersion
 	}
 
 	async prompting () {
@@ -12,18 +12,32 @@ module.exports = class extends Generator {
 			{ type: 'confirm', name: 'dockerfile', message: 'Do you want a Dockerfile?', default: true }
 		])
 
-		if (this.answers.dockerfile) {
-			this.tcpPort = typeof (this.config.get('port')) !== 'undefined'
-				? this.config.get('port')
-				: await this.prompt({ type: 'input', name: 'tcpPort', message: 'Container listening port', default: '8080' })
+		if (this.answers.dockerfile && typeof (this.config.get('port')) === 'undefined') {
+			this.config.set(await this.prompt({
+				type: 'input',
+				name: 'port',
+				message: 'Container listening port',
+				default: '8080',
+				validate: port => {
+					const p = Number(port)
+					if (isNaN(p)) { return 'Container listening port must be an integer' }
+					if (p < 0 || p > 65535) { return 'Container listening port must be in the range: [0,65535]' }
+					return true
+				}
+			}))
 		}
 	}
 
 	async writing () {
 		if (this.answers.devcontainer) {
-			this.copyTemplate(
+			this.config.defaults({ extensions: [] })
+			this.renderTemplate(
 				'devcontainer',
-				'.devcontainer'
+				'.devcontainer',
+				{
+					version: this.jolieVersion,
+					extensions: ['jolie.vscode-jolie', ...this.config.get('extensions')]
+				}
 			)
 		}
 
@@ -32,8 +46,8 @@ module.exports = class extends Generator {
 				'Dockerfile',
 				'Dockerfile',
 				{
-					moduleName: this.module_name,
-					tcpPort: this.tcpPort
+					version: this.jolieVersion,
+					tcpPort: this.config.get('port')
 				}
 			)
 		}

--- a/generators/app/docker.js
+++ b/generators/app/docker.js
@@ -13,18 +13,20 @@ module.exports = class extends Generator {
 		])
 
 		if (this.answers.dockerfile && typeof (this.config.get('port')) === 'undefined') {
-			this.config.set(await this.prompt({
-				type: 'input',
-				name: 'port',
-				message: 'Container listening port',
-				default: '8080',
-				validate: port => {
-					const p = Number(port)
-					if (isNaN(p)) { return 'Container listening port must be an integer' }
-					if (p < 0 || p > 65535) { return 'Container listening port must be in the range: [0,65535]' }
-					return true
-				}
-			}))
+			this.tcpPort = typeof (this.config.get('port')) !== 'undefined'
+				? this.config.get('port')
+				: await this.prompt({
+					type: 'input',
+					name: 'tcpPort',
+					message: 'Container listening port',
+					default: '8080',
+					validate: port => {
+						const p = Number(port)
+						if (isNaN(p)) { return 'Container listening port must be an integer' }
+						if (p < 0 || p > 65535) { return 'Container listening port must be in the range: [0,65535]' }
+						return true
+					}
+				}).then(answer => answer.tcpPort)
 		}
 	}
 
@@ -47,7 +49,7 @@ module.exports = class extends Generator {
 				'Dockerfile',
 				{
 					version: this.jolieVersion,
-					tcpPort: this.config.get('port')
+					tcpPort: this.tcpPort
 				}
 			)
 		}

--- a/generators/app/templates/Dockerfile
+++ b/generators/app/templates/Dockerfile
@@ -1,8 +1,8 @@
-FROM jolielang/jolie:edge
+FROM jolielang/jolie:<%- version %>
 
 WORKDIR /app
 COPY . .
 <% if (typeof tcpPort !== 'undefined') { %>
-EXPOSE <%= tcpPort %>
+EXPOSE <%- tcpPort %>
 <% } %>
-CMD ["jolie", "<%= moduleName %>"]
+CMD ["npm", "start"]

--- a/generators/app/templates/devcontainer/devcontainer.json
+++ b/generators/app/templates/devcontainer/devcontainer.json
@@ -1,9 +1,8 @@
 {
-	"image": "jolielang/jolie:edge-dev",
-	"containerUser": "jolie",
+	"image": "jolielang/jolie:<%- version %>-dev",
 	"customizations": {
 		"vscode": {
-			"extensions": ["jolie.vscode-jolie"]
+			"extensions": [<%- extensions.map(ext => `"${ext}"`).join(", ") %>]
 		}
 	}
 }

--- a/generators/service/dev.js
+++ b/generators/service/dev.js
@@ -24,29 +24,27 @@ module.exports = class extends Generator {
 
 			if (this.service.language === 'jolie') {
 				const interfaceName = `${this.service.name}Interface`
-				this.config.merge({
-					jolie_file: {
-						interfaces: [{
-							name: interfaceName,
-							rrs: [{
-								name: 'hello',
-								requestType: 'void',
-								responseType: 'string'
-							}],
-							ows: []
+				this.config.set('file', {
+					interfaces: [{
+						name: interfaceName,
+						rrs: [{
+							name: 'hello',
+							requestType: 'void',
+							responseType: 'string'
 						}],
-						services: [{
-							name: this.service.name,
-							execution: 'concurrent',
-							input_ports: [{
-								name: 'ip',
-								location: 'local',
-								protocol: 'sodep',
-								interfaces: [interfaceName]
-							}],
-							code: '[hello()(res) { res = "World" }]'
-						}]
-					}
+						ows: []
+					}],
+					services: [{
+						name: this.service.name,
+						execution: 'concurrent',
+						input_ports: [{
+							name: 'ip',
+							location: 'local',
+							protocol: 'sodep',
+							interfaces: [interfaceName]
+						}],
+						code: '[hello()(res) { res = "World" }]'
+					}]
 				})
 			}
 

--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -5,6 +5,7 @@ module.exports = class extends Generator {
 		super(args, opts)
 		this.module = opts.module
 		this.packageJSONAnswers = opts.packageJSONAnswers
+		this.jolieVersion = opts.jolieVersion
 	}
 
 	async prompting () {
@@ -27,19 +28,18 @@ module.exports = class extends Generator {
 			}
 		])
 
-		this.composeWith(require.resolve(`./${this.service.language}`), { service_name: this.service.name, module: this.module, packageJSONAnswers: this.packageJSONAnswers })
+		this.composeWith(require.resolve(`./${this.service.language}`), { service_name: this.service.name, module: this.module, packageJSONAnswers: this.packageJSONAnswers, jolieVersion: this.jolieVersion })
 		this.composeWith(require.resolve('./dev'), { service: this.service, module: this.module })
 	}
 
 	async writing () {
-		const jolieFile = typeof (this.config.get('jolie_file')) !== 'undefined'
-			? this.config.get('jolie_file')
-			: { services: [{ name: this.service.name }] }
-
+		this.config.defaults({
+			file: { services: [{ name: this.service.name }] }
+		})
 		this.renderTemplate(
 			'service/service.ol',
 			this.module,
-			{ file: jolieFile }
+			{ file: this.config.get('file') }
 		)
 	}
 }

--- a/generators/service/templates/service/partials/interfaces.ejs
+++ b/generators/service/templates/service/partials/interfaces.ejs
@@ -1,6 +1,6 @@
 interface <%- interface.name %> {
 <%_ interface.rrs?.forEach( rr => { _%>
-    RequestResponse: <%- rr.name %>(<%- rr.requestType %>)(<%- rr.responseType %>)    
+    RequestResponse: <%- rr.name %>(<%- rr.requestType %>)(<%- rr.responseType %>)
 <%_ } ) _%>
 <%_ interface.ows?.forEach( ow => { _%>
     OneWay: <%- ow.name %>(<%- ow.requestType %>)

--- a/generators/web/index.js
+++ b/generators/web/index.js
@@ -22,6 +22,11 @@ module.exports = class extends Generator {
 			})
 			await this.addDevDependencies({ 'webpack-cli': '^4', webpack: '^5' })
 		}
+		this.packageJson.merge({
+			scripts: {
+				start: `jolie ${this.module}`
+			}
+		})
 	}
 
 	async writing () {
@@ -45,7 +50,7 @@ module.exports = class extends Generator {
 		}
 	}
 
-	install () {
-		this.spawnCommandSync('npx', ['@jolie/jpm', 'install', '@jolie/leonardo'])
+	async install () {
+		this.spawnCommandSync('jpm', ['install', '@jolie/leonardo'])
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,11 +1548,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },


### PR DESCRIPTION
Changes made:

1. Changed the 'generate' script added to package.json in service/java.js to be compatible with recent changes to jolie2java.
2. Added jpm as a dev dependency such that it can be version controlled, and made the version an earlier version because of an issue with jpm 3.0.0.
3. Changed the images of the generated Dockerfiles and devcontainers to use fixed versions rather than *edge*.
4. Made it more transparent what happens when the local machine does not have Jolie installed.
5. Added functionality such that the generated devcontainer now has the java pack extension when choosing Java as the implementation language for a service.
6. Changed the generated Dockerfile to use *npm start* as its `CMD`, such that it works as expected when making a standalone Java service.
7. Added extra validations to certain prompts, as well as adding the *store* option to prompts that a user would likely want to have remember their previous choice (e.g. author).
8. Other minor bug fixes and improvements.